### PR TITLE
Add Apple Silicon training docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,9 @@ embeddings, tokenizer_state = pipeline.embed(context)
 ### Pretraining, fine-tuning and evaluation
 
 Scripts for pretraining, fine-tuning and evaluating Chronos models can be found in [this folder](./scripts/).
+If you would like to reproduce the training of `chronos-t5-tiny` on Apple Silicon,
+please refer to the step-by-step guide in
+[docs/APPLE_SILICON_TRAINING.md](docs/APPLE_SILICON_TRAINING.md).
 
 ## :floppy_disk: Datasets
 

--- a/docs/APPLE_SILICON_TRAINING.md
+++ b/docs/APPLE_SILICON_TRAINING.md
@@ -1,0 +1,55 @@
+# Training Chronos-T5-Tiny on Apple Silicon
+
+This guide explains how to reproduce the training of `chronos-t5-tiny` on macOS machines equipped with Apple Silicon (M1/M2 chips). The commands below assume you have Python 3.10+ installed.
+
+## 1. Install Dependencies
+
+```bash
+# Create and activate a clean virtual environment
+python3 -m venv chronos-venv
+source chronos-venv/bin/activate
+
+# Install PyTorch with MPS support
+pip install torch torchvision torchaudio
+
+# Install Chronos from source with training extras
+pip install -e ".[training]"
+```
+
+PyTorch wheels for macOS include MPS support out of the box. Ensure your environment variables allow PyTorch to utilise the GPU:
+
+```bash
+export PYTORCH_MPS_HIGH_WATERMARK_RATIO=0.0
+```
+
+## 2. Prepare Datasets
+
+Download the pretraining datasets referenced in the Chronos paper. The files can be obtained from the following Hugging Face repositories:
+
+- [autogluon/chronos_datasets](https://huggingface.co/datasets/autogluon/chronos_datasets)
+- [autogluon/chronos_datasets_extra](https://huggingface.co/datasets/autogluon/chronos_datasets_extra)
+
+After downloading, update the dataset paths in `scripts/training/configs/chronos-t5-tiny-mps.yaml`.
+
+## 3. Start Training
+
+Use the modified configuration designed for Apple Silicon:
+
+```bash
+python scripts/training/train.py \
+    --config scripts/training/configs/chronos-t5-tiny-mps.yaml
+```
+
+Training checkpoints and logs are written under `output/run-*`. The final model weights are saved inside `checkpoint-final/` within the run directory.
+
+## 4. Loading the Trained Model
+
+Once training finishes, load the resulting model with:
+
+```python
+from chronos import ChronosPipeline
+
+pipeline = ChronosPipeline.from_pretrained("output/run-*/checkpoint-final")
+```
+
+The pipeline object can then be used to generate forecasts or pushed to the Hugging Face Hub.

--- a/scripts/training/configs/chronos-t5-tiny-mps.yaml
+++ b/scripts/training/configs/chronos-t5-tiny-mps.yaml
@@ -1,0 +1,35 @@
+training_data_paths:
+- "/path/to/tsmixup-data.arrow"
+- "/path/to/kernelsynth-data.arrow"
+probability:
+- 0.9
+- 0.1
+context_length: 512
+prediction_length: 64
+min_past: 60
+max_steps: 200_000
+save_steps: 100_000
+log_steps: 500
+per_device_train_batch_size: 32
+learning_rate: 0.001
+optim: adamw_torch
+num_samples: 20
+shuffle_buffer_length: 100_000
+gradient_accumulation_steps: 1
+model_id: google/t5-efficient-tiny
+model_type: seq2seq
+random_init: true
+tie_embeddings: true
+output_dir: ./output/
+tf32: false
+torch_compile: false
+tokenizer_class: "MeanScaleUniformBins"
+tokenizer_kwargs:
+  low_limit: -15.0
+  high_limit: 15.0
+n_tokens: 4096
+lr_scheduler_type: linear
+warmup_ratio: 0.0
+dataloader_num_workers: 1
+max_missing_prop: 0.9
+use_eos_token: true


### PR DESCRIPTION
## Summary
- add guide for training Chronos-T5-Tiny on Apple Silicon
- link to guide from README
- add Apple Silicon training config

## Testing
- `git status --short`